### PR TITLE
Added creatable safe.

### DIFF
--- a/Authorization/Creatable.spec.ts
+++ b/Authorization/Creatable.spec.ts
@@ -15,3 +15,13 @@ describe("Authorization.Creatable", () => {
 		expect(model.Authorization.Creatable.is(authorization)).toBeTruthy()
 	})
 })
+describe("Authorization.Creatable.Safe", () => {
+	it("is", async () => {
+		const authorization: model.Authorization.Creatable = {
+			number: "test001",
+			currency: "SEK",
+			amount: 100,
+		}
+		expect(model.Authorization.Creatable.Safe.is(authorization)).toBeTruthy()
+	})
+})

--- a/Authorization/Creatable.ts
+++ b/Authorization/Creatable.ts
@@ -28,4 +28,21 @@ export namespace Creatable {
 				value.account == "create" && value.amount == undefined && value.currency == undefined && Card.Creatable.is(value.card)
 			)
 	}
+	export type Safe = Omit<Creatable, "card">
+	export namespace Safe {
+		// tslint:disable-next-line: no-shadowed-variable
+		export function is(value: Safe | any): value is Safe {
+			return typeof(value) == "object" &&
+				(value.number == undefined || typeof(value.number) == "string") &&
+				(value.descriptor == undefined || typeof(value.descriptor) == "string") &&
+				(value.ip == undefined || typeof(value.ip) == "string") && (
+					typeof(value.amount) == "number" &&
+					isoly.Currency.is(value.currency) &&
+					(
+						value.account == "create" || value.account == undefined || authly.Identifier.is(value.account)
+					) ||
+					value.account == "create" && value.amount == undefined && value.currency == undefined
+				)
+		}
+	}
 }

--- a/Authorization/index.ts
+++ b/Authorization/index.ts
@@ -32,5 +32,10 @@ export namespace Authorization {
 	export namespace Creatable {
 		// tslint:disable-next-line: no-shadowed-variable
 		export const is = AuthorizationCreatable.is
+		export type Safe = AuthorizationCreatable.Safe
+		export namespace Safe {
+			// tslint:disable-next-line: no-shadowed-variable
+			export const is = AuthorizationCreatable.Safe.is
+		}
 	}
 }


### PR DESCRIPTION
A `Authorization.Creatable` that does not contain any card data and therefore is "safe" to handle outside the PCI scope.