### PR TITLE
Made mid, mcc and bin optional.

### DIFF
--- a/Merchant/Creatable.spec.ts
+++ b/Merchant/Creatable.spec.ts
@@ -24,6 +24,7 @@ describe("Merchant.Creatable", () => {
 		},
 	}
 	it("is", () => expect(model.Merchant.Creatable.is(key)).toBeTruthy())
+	it("is simple", () => expect(model.Merchant.Creatable.is({ ...key, mid: undefined, mcc: undefined, bin: undefined })).toBeTruthy())
 	it("flaw", () => {
 		const k = key
 		delete k.url

--- a/Merchant/Creatable.ts
+++ b/Merchant/Creatable.ts
@@ -9,9 +9,9 @@ export interface Creatable {
 	descriptor?: string
 	country: isoly.CountryCode.Alpha2
 	acquirer: Acquirer.Settings
-	mid: string,
-	mcc: CategoryCode
-	bin: {
+	mid?: string,
+	mcc?: CategoryCode
+	bin?: {
 		[scheme: string]: string | undefined,
 		amex?: string,
 		dankort?: string,
@@ -41,9 +41,9 @@ export namespace Creatable {
 			(value.descriptor == undefined || typeof value.descriptor == "string") &&
 			isoly.CountryCode.Alpha2.is(value.country) &&
 			Acquirer.Settings.is(value.acquirer) &&
-			typeof value.mid == "string" &&
-			CategoryCode.is(value.mcc) &&
-			binIs(value.bin) &&
+			(value.mid == undefined || typeof value.mid == "string") &&
+			(value.mcc == undefined || CategoryCode.is(value.mcc)) &&
+			(value.bin == undefined || binIs(value.bin)) &&
 			(value.emv3d == undefined || emv3dIs(value.emv3d))
 	}
 	function emv3dIs(value: any): value is { protocol: "ch3d1", url: string } {
@@ -73,9 +73,9 @@ export namespace Creatable {
 					(value.descriptor == undefined || typeof value.descriptor  == "string") || { property: "descriptor", type: "string" },
 					isoly.CountryCode.Alpha2.is(value.country) || { property: "country", type: "isoly.CountryCode" },
 					Acquirer.Settings.is(value.acquirer) || { property: "acquirer", type: "model.Acquirer.Settings" },
-					typeof value.mid == "string" || { property: "mid", type: "string" },
-					CategoryCode.is(value.mcc) || { property: "mcc", type: "model.Merchant.CategoryCode" },
-					binIs(value.bin) || {
+					value.mid == undefined || typeof value.mid == "string" || { property: "mid", type: "string" },
+					value.mcc == undefined || CategoryCode.is(value.mcc) || { property: "mcc", type: "model.Merchant.CategoryCode" },
+					value.bin == undefined || binIs(value.bin) || {
 						type: "{ amex?: string, dankort?: string, diners?: string, discover?: string, electron?: string, interpayment?: string, jcb?: string, maestro?: string, mastercard?: string, unionpay?: string, visa?: string }",
 						flaws: typeof value.bin != "object" ? undefined :
 							[

--- a/Merchant/Key.ts
+++ b/Merchant/Key.ts
@@ -13,8 +13,8 @@ export namespace Key {
 	export function is(value: Key | any): value is Key {
 		return Creatable.is(value) &&
 			authly.Identifier.is((value as any).sub) &&
-			typeof((value as any).iss) == "string" &&
-			typeof((value as any).iat) == "number" &&
+			typeof(value as any).iss == "string" &&
+			typeof(value as any).iat == "number" &&
 			((value as any).aud == "public" || (value as any).aud == "private")
 	}
 	export function flaw(value: any | Key): gracely.Flaw {
@@ -22,10 +22,10 @@ export namespace Key {
 			type: "model.Merchant.Key",
 			flaws: typeof(value) != "object" ? undefined :
 				[
-					typeof(value.sub) == "string" || { property: "sub", type: "authly.Identifier", condition: "Merchant identifier." },
-					typeof(value.iss) == "string" || { property: "iss", type: "string", condition: "Key issuer." },
-					typeof(value.aud) == "string" || { property: "aud", type: `"public" | "private"`, condition: "Key audience." },
-					typeof(value.iat) == "number" || { property: "iat", type: "number", condition: "Issued timestamp." },
+					typeof value.sub == "string" || { property: "sub", type: "authly.Identifier", condition: "Merchant identifier." },
+					typeof value.iss == "string" || { property: "iss", type: "string", condition: "Key issuer." },
+					typeof value.aud == "string" || { property: "aud", type: `"public" | "private"`, condition: "Key audience." },
+					typeof value.iat == "number" || { property: "iat", type: "number", condition: "Issued timestamp." },
 					...Creatable.flaw(value).flaws || [],
 				].filter(gracely.Flaw.is) as gracely.Flaw[],
 		}


### PR DESCRIPTION
## Change
Makes following properties `mcc`, `mid`, `bin` optional on merchants.

## Rationale
Properties are currently not needed for the function of the software itself.

## Impact
Simpler to create new API keys.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
