### PR TITLE
verify fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,9 +1006,9 @@
    "dev": true
   },
   "authly": {
-   "version": "0.0.34",
-   "resolved": "https://registry.npmjs.org/authly/-/authly-0.0.34.tgz",
-   "integrity": "sha512-98ejzKmv3/nE0ycsd3saH44MaogkcvKYzcLoswFV8dPWu7P17ecK9uITimgm/90OFFKmXHXUZTNKOuIEtQqgOw==",
+   "version": "0.0.37",
+   "resolved": "https://registry.npmjs.org/authly/-/authly-0.0.37.tgz",
+   "integrity": "sha512-1+vKjCHa9OxIh0o+pAiFvhv4GR48WfIvdKlxNOpwKfyf5/6IKTmzUjp6qMZXixqwVKZw2p31Y78utO6q4GA6uA==",
    "requires": {
     "node-webcrypto-ossl": "1.0.48"
    }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "clean": "rm -rf dist node_modules coverage"
  },
  "dependencies": {
-  "authly": "0.0.34",
+  "authly": "0.0.37",
   "gracely": "0.0.24",
   "isoly": "0.0.11"
  },


### PR DESCRIPTION
## Change
Updated authly dependency, responsible for encoding and decoding jwt. This will impact the verify functionality of this model. It will now add ability to spot url-encoded jwt `(can include "-" and "_" but not "+" or "/")` and correctly decode these as well as standard-encoded jwt `(can include "+" and "/" but not "-" or "_")`. Previously only possible to decode standard-encoded jwt.

## Rationale
To keep it in sync with the rest of the project that will go from signing and verifying standard-encoded jwt to url-encoded jwt.

## Impact
Should have no immediate effects on the system, only add future verifying capabilities.

## Risk
If not updating it might in the future have issues verifying some jwt encoded strings. Only risk would be failed jwt decoding which would result in unauthorized access which shouldn't happen according to several tests.
This should have no increased risks on rest of the system. No extra risk analysis is necessary.

## Rollback
If something would immediately fail after deploying, this update can be rollbacked without consequences as only some future functionality might sometimes fail verification, not anything presently implemented.
