### PR TITLE
Updated authly version with mscrypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1006,9 +1006,9 @@
    "dev": true
   },
   "authly": {
-   "version": "0.0.37",
-   "resolved": "https://registry.npmjs.org/authly/-/authly-0.0.37.tgz",
-   "integrity": "sha512-1+vKjCHa9OxIh0o+pAiFvhv4GR48WfIvdKlxNOpwKfyf5/6IKTmzUjp6qMZXixqwVKZw2p31Y78utO6q4GA6uA==",
+   "version": "0.0.38",
+   "resolved": "https://registry.npmjs.org/authly/-/authly-0.0.38.tgz",
+   "integrity": "sha512-lret5TecRqvBYuq4qqJP0FhxRLvm4ueEWJ2VPVoVnSlXh50xS3/zjRBtgJ8zYEjQdkLPYuXQbgnldnDUjFTI+Q==",
    "requires": {
     "node-webcrypto-ossl": "1.0.48"
    }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "clean": "rm -rf dist node_modules coverage"
  },
  "dependencies": {
-  "authly": "0.0.37",
+  "authly": "0.0.38",
   "gracely": "0.0.24",
   "isoly": "0.0.11"
  },


### PR DESCRIPTION
## Change
Updated authly dependency to include a crypto version for Internet Explorer 11.

## Rationale
Internet Explorer 11 has a different crypto version. Without the change, our UI:s won't run on Internet Explorer 11.

## Impact
If the normal crypto doesn't exist, which is only the case for Internet Explorer 11, the msCrypto version will be used instead.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
