### PR TITLE
often used helper types

### DIFF
--- a/AuthorizationV2/Change/Change02.ts
+++ b/AuthorizationV2/Change/Change02.ts
@@ -1,0 +1,15 @@
+import * as isoly from "isoly"
+import { Range02 } from "../Range/Range02"
+
+export interface Change02 {
+	date: isoly.DateTime
+	indicator: Range02
+}
+
+export namespace Change02 {
+	export function is(value: Change02 | any): value is Change02 {
+		return typeof value == "object" &&
+			isoly.DateTime.is(value.date) &&
+			Range02.is(value.indicator)
+	}
+}

--- a/AuthorizationV2/Change/Change03.ts
+++ b/AuthorizationV2/Change/Change03.ts
@@ -1,0 +1,15 @@
+import * as isoly from "isoly"
+import { Range03 } from "../Range/Range03"
+
+export interface Change03 {
+	date: isoly.DateTime
+	indicator: Range03
+}
+
+export namespace Change03 {
+	export function is(value: Change03 | any): value is Change03 {
+		return typeof value == "object" &&
+			isoly.DateTime.is(value.date) &&
+			Range03.is(value.indicator)
+	}
+}

--- a/AuthorizationV2/Change/Change04.ts
+++ b/AuthorizationV2/Change/Change04.ts
@@ -1,0 +1,15 @@
+import * as isoly from "isoly"
+import { Range04 } from "../Range/Range04"
+
+export interface Change04 {
+	date: isoly.DateTime
+	indicator: Range04
+}
+
+export namespace Change04 {
+	export function is(value: Change04 | any): value is Change04 {
+		return typeof value == "object" &&
+			isoly.DateTime.is(value.date) &&
+			Range04.is(value.indicator)
+	}
+}

--- a/AuthorizationV2/Change/Change05.ts
+++ b/AuthorizationV2/Change/Change05.ts
@@ -1,0 +1,15 @@
+import * as isoly from "isoly"
+import { Range05 } from "../Range/Range05"
+
+export interface Change05 {
+	date: isoly.DateTime
+	indicator: Range05
+}
+
+export namespace Change05 {
+	export function is(value: Change05 | any): value is Change05 {
+		return typeof value == "object" &&
+			isoly.DateTime.is(value.date) &&
+			Range05.is(value.indicator)
+	}
+}

--- a/AuthorizationV2/Change/Change06.ts
+++ b/AuthorizationV2/Change/Change06.ts
@@ -1,0 +1,15 @@
+import * as isoly from "isoly"
+import { Range06 } from "../Range/Range06"
+
+export interface Change06 {
+	date: isoly.DateTime
+	indicator: Range06
+}
+
+export namespace Change06 {
+	export function is(value: Change06 | any): value is Change06 {
+		return typeof value == "object" &&
+			isoly.DateTime.is(value.date) &&
+			Range06.is(value.indicator)
+	}
+}

--- a/AuthorizationV2/Change/Change07.ts
+++ b/AuthorizationV2/Change/Change07.ts
@@ -1,0 +1,15 @@
+import * as isoly from "isoly"
+import { Range07 } from "../Range/Range07"
+
+export interface Change07 {
+	date: isoly.DateTime
+	indicator: Range07
+}
+
+export namespace Change07 {
+	export function is(value: Change07 | any): value is Change07 {
+		return typeof value == "object" &&
+			isoly.DateTime.is(value.date) &&
+			Range07.is(value.indicator)
+	}
+}

--- a/AuthorizationV2/Change/index.spec.ts
+++ b/AuthorizationV2/Change/index.spec.ts
@@ -1,0 +1,61 @@
+import * as isoly from "isoly"
+import { Change02 } from "./Change02"
+import { Change03 } from "./Change03"
+import { Change04 } from "./Change04"
+import { Change05 } from "./Change05"
+import { Change06 } from "./Change06"
+import { Change07 } from "./Change07"
+
+describe("Change is", () => {
+	it("is 01-02", async () => {
+		expect(Change02.is({ date: isoly.DateTime.now(), indicator: "00" })).toBeFalsy()
+		expect(Change02.is({ date: isoly.DateTime.now(), indicator: "01" })).toBeTruthy()
+		expect(Change02.is({ date: isoly.DateTime.now(), indicator: "02" })).toBeTruthy()
+		expect(Change02.is({ date: isoly.DateTime.now(), indicator: "03" })).toBeFalsy()
+	})
+	it("is 01-03", async () => {
+		expect(Change03.is({ date: isoly.DateTime.now(), indicator: "00" })).toBeFalsy()
+		expect(Change03.is({ date: isoly.DateTime.now(), indicator: "01" })).toBeTruthy()
+		expect(Change03.is({ date: isoly.DateTime.now(), indicator: "02" })).toBeTruthy()
+		expect(Change03.is({ date: isoly.DateTime.now(), indicator: "03" })).toBeTruthy()
+		expect(Change03.is({ date: isoly.DateTime.now(), indicator: "04" })).toBeFalsy()
+	})
+	it("is 01-04", async () => {
+		expect(Change04.is({ date: isoly.DateTime.now(), indicator: "00" })).toBeFalsy()
+		expect(Change04.is({ date: isoly.DateTime.now(), indicator: "01" })).toBeTruthy()
+		expect(Change04.is({ date: isoly.DateTime.now(), indicator: "02" })).toBeTruthy()
+		expect(Change04.is({ date: isoly.DateTime.now(), indicator: "03" })).toBeTruthy()
+		expect(Change04.is({ date: isoly.DateTime.now(), indicator: "04" })).toBeTruthy()
+		expect(Change04.is({ date: isoly.DateTime.now(), indicator: "05" })).toBeFalsy()
+	})
+	it("is 01-05", async () => {
+		expect(Change05.is({ date: isoly.DateTime.now(), indicator: "00" })).toBeFalsy()
+		expect(Change05.is({ date: isoly.DateTime.now(), indicator: "01" })).toBeTruthy()
+		expect(Change05.is({ date: isoly.DateTime.now(), indicator: "02" })).toBeTruthy()
+		expect(Change05.is({ date: isoly.DateTime.now(), indicator: "03" })).toBeTruthy()
+		expect(Change05.is({ date: isoly.DateTime.now(), indicator: "04" })).toBeTruthy()
+		expect(Change05.is({ date: isoly.DateTime.now(), indicator: "05" })).toBeTruthy()
+		expect(Change05.is({ date: isoly.DateTime.now(), indicator: "06" })).toBeFalsy()
+	})
+	it("is 01-06", async () => {
+		expect(Change06.is({ date: isoly.DateTime.now(), indicator: "00" })).toBeFalsy()
+		expect(Change06.is({ date: isoly.DateTime.now(), indicator: "01" })).toBeTruthy()
+		expect(Change06.is({ date: isoly.DateTime.now(), indicator: "02" })).toBeTruthy()
+		expect(Change06.is({ date: isoly.DateTime.now(), indicator: "03" })).toBeTruthy()
+		expect(Change06.is({ date: isoly.DateTime.now(), indicator: "04" })).toBeTruthy()
+		expect(Change06.is({ date: isoly.DateTime.now(), indicator: "05" })).toBeTruthy()
+		expect(Change06.is({ date: isoly.DateTime.now(), indicator: "06" })).toBeTruthy()
+		expect(Change06.is({ date: isoly.DateTime.now(), indicator: "07" })).toBeFalsy()
+	})
+	it("is 01-07", async () => {
+		expect(Change07.is({ date: isoly.DateTime.now(), indicator: "00" })).toBeFalsy()
+		expect(Change07.is({ date: isoly.DateTime.now(), indicator: "01" })).toBeTruthy()
+		expect(Change07.is({ date: isoly.DateTime.now(), indicator: "02" })).toBeTruthy()
+		expect(Change07.is({ date: isoly.DateTime.now(), indicator: "03" })).toBeTruthy()
+		expect(Change07.is({ date: isoly.DateTime.now(), indicator: "04" })).toBeTruthy()
+		expect(Change07.is({ date: isoly.DateTime.now(), indicator: "05" })).toBeTruthy()
+		expect(Change07.is({ date: isoly.DateTime.now(), indicator: "06" })).toBeTruthy()
+		expect(Change07.is({ date: isoly.DateTime.now(), indicator: "07" })).toBeTruthy()
+		expect(Change07.is({ date: isoly.DateTime.now(), indicator: "08" })).toBeFalsy()
+	})
+})

--- a/AuthorizationV2/Change/index.ts
+++ b/AuthorizationV2/Change/index.ts
@@ -1,0 +1,33 @@
+import { Change02 as CChange02 } from "./Change02"
+import { Change03 as CChange03 } from "./Change03"
+import { Change04 as CChange04 } from "./Change04"
+import { Change05 as CChange05 } from "./Change05"
+import { Change06 as CChange06 } from "./Change06"
+import { Change07 as CChange07 } from "./Change07"
+
+export namespace Change {
+	export type Change02 = CChange02
+	export namespace Change02 {
+		export const is = CChange02.is
+	}
+	export type Change03 = CChange03
+	export namespace Change03 {
+		export const is = CChange03.is
+	}
+	export type Change04 = CChange04
+	export namespace Change04 {
+		export const is = CChange04.is
+	}
+	export type Change05 = CChange05
+	export namespace Change05 {
+		export const is = CChange05.is
+	}
+	export type Change06 = CChange06
+	export namespace Change06 {
+		export const is = CChange06.is
+	}
+	export type Change07 = CChange07
+	export namespace Change07 {
+		export const is = CChange07.is
+	}
+}

--- a/AuthorizationV2/Range/Range02.ts
+++ b/AuthorizationV2/Range/Range02.ts
@@ -1,0 +1,7 @@
+export type Range02 = "01" | "02"
+
+export namespace Range02 {
+	export function is(value: Range02 | any): value is Range02 {
+		return value == "01" || value == "02"
+	}
+}

--- a/AuthorizationV2/Range/Range03.ts
+++ b/AuthorizationV2/Range/Range03.ts
@@ -1,0 +1,9 @@
+import { Range02 } from "./Range02"
+
+export type Range03 = Range02 | "03"
+
+export namespace Range03 {
+	export function is(value: Range03 | any): value is Range03 {
+		return Range02.is(value) || value == "03"
+	}
+}

--- a/AuthorizationV2/Range/Range04.ts
+++ b/AuthorizationV2/Range/Range04.ts
@@ -1,0 +1,9 @@
+import { Range03 } from "./Range03"
+
+export type Range04 = Range03 | "04"
+
+export namespace Range04 {
+	export function is(value: Range04 | any): value is Range04 {
+		return Range03.is(value) || value == "04"
+	}
+}

--- a/AuthorizationV2/Range/Range05.ts
+++ b/AuthorizationV2/Range/Range05.ts
@@ -1,0 +1,9 @@
+import { Range04 } from "./Range04"
+
+export type Range05 = Range04 | "05"
+
+export namespace Range05 {
+	export function is(value: Range05 | any): value is Range05 {
+		return Range04.is(value) || value == "05"
+	}
+}

--- a/AuthorizationV2/Range/Range06.ts
+++ b/AuthorizationV2/Range/Range06.ts
@@ -1,0 +1,9 @@
+import { Range05 } from "./Range05"
+
+export type Range06 = Range05 | "06"
+
+export namespace Range06 {
+	export function is(value: Range06 | any): value is Range06 {
+		return Range05.is(value) || value == "06"
+	}
+}

--- a/AuthorizationV2/Range/Range07.ts
+++ b/AuthorizationV2/Range/Range07.ts
@@ -1,0 +1,9 @@
+import { Range06 } from "./Range06"
+
+export type Range07 = Range06 | "07"
+
+export namespace Range07 {
+	export function is(value: Range07 | any): value is Range07 {
+		return Range06.is(value) || value == "07"
+	}
+}

--- a/AuthorizationV2/Range/Range8099.ts
+++ b/AuthorizationV2/Range/Range8099.ts
@@ -1,0 +1,8 @@
+export type Range8099 = "80" | "81" | "82" | "83" | "84" | "85" | "86" | "87" | "88" | "89" | "90" | "90" | "91" | "92" | "93" | "94" | "95" | "96" | "97" | "98" | "99"
+
+export namespace Range8099 {
+	export function is(value: Range8099 | any): value is Range8099 {
+		return value == "80" || value == "81" || value == "82" || value == "83" || value == "84" || value == "85" || value == "86" || value == "87" || value == "88" || value == "89"
+				|| value == "90" || value == "91" || value == "92" || value == "93" || value == "94" || value == "95" || value == "96" || value == "97" || value == "98" || value == "99"
+	}
+}

--- a/AuthorizationV2/Range/index.ts
+++ b/AuthorizationV2/Range/index.ts
@@ -1,0 +1,38 @@
+import { Range02 as CRange02 } from "./Range02"
+import { Range03 as CRange03 } from "./Range03"
+import { Range04 as CRange04 } from "./Range04"
+import { Range05 as CRange05 } from "./Range05"
+import { Range06 as CRange06 } from "./Range06"
+import { Range07 as CRange07 } from "./Range07"
+import { Range8099 as CRange8099 } from "./Range8099"
+
+export namespace Range {
+	export type Range02 = CRange02
+	export namespace Range02 {
+		export const is = CRange02.is
+	}
+	export type Range03 = CRange03
+	export namespace Range03 {
+		export const is = CRange03.is
+	}
+	export type Range04 = CRange04
+	export namespace Range04 {
+		export const is = CRange04.is
+	}
+	export type Range05 = CRange05
+	export namespace Range05 {
+		export const is = CRange05.is
+	}
+	export type Range06 = CRange06
+	export namespace Range06 {
+		export const is = CRange06.is
+	}
+	export type Range07 = CRange07
+	export namespace Range07 {
+		export const is = CRange07.is
+	}
+	export type Range8099 = CRange8099
+	export namespace Range8099 {
+		export const is = CRange8099.is
+	}
+}


### PR DESCRIPTION
## Change
Added helper types very often used with 3-D Secure Version 2.

## Rationale
To provide easier type checking for "01" | "02"  ... "07" type of option parameters often used within 3-D Secure Version 2 protocol.

## Impact
Avoiding a lot of code duplication and minimize code and risk of errors for programmer when doing almost the same thing multiple times.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
