### PR TITLE
Message extension

### DIFF
--- a/AuthorizationV2/Extension.ts
+++ b/AuthorizationV2/Extension.ts
@@ -1,0 +1,17 @@
+export interface Extension {
+	critical: boolean
+	data: any
+	id: string
+	name: string
+}
+
+// tslint:disable-next-line: no-namespace
+export namespace Extension {
+	export function is(value: Extension | any): value is Extension {
+		return typeof value == "object" &&
+			typeof value.critical == "boolean" &&
+			value.data != undefined &&
+			typeof value.id == "string" && value.id.length <= 64 &&
+			typeof value.name == "string" && value.name.length <= 64
+	}
+}


### PR DESCRIPTION
## Change
Adding our version of the type `MessageExtension` specified in 3-D Secure Verison 2.

## Rationale
To be able to handle and send `MessageExtension` data.

## Impact
Providing additional ability to handle and send information.

## Risk
As `MessageExtension` type from 3-D secure api are defined as _"Data necessary to support requirements not otherwise defined in the 3-D Secure message"_, we will handle information being sent as parameters with type `MessageExtension` as if it might contain sensitive information according to our risk-analysis [3-D Secure v2 api added risks #215](https://github.com/cardfunc/projects/pull/215)

## Rollback
For rollback, it is enough to revert the commit and redeploy.
