### PR TITLE
single_use

### DIFF
--- a/Card/Token.ts
+++ b/Card/Token.ts
@@ -2,14 +2,14 @@ import * as authly from "authly"
 import { verify as verifyToken } from "../verify"
 
 export interface Token {
-	type: "single_use" | "recurring"
+	type: "single use" | "recurring"
 	card: authly.Identifier
 }
 
 export namespace Token {
 	export function is(value: Token | any): value is Token {
 		return typeof value == "object" &&
-			(value.type == "single_use" || value.type == "recurring") &&
+			(value.type == "single use" || value.type == "recurring") &&
 			authly.Identifier.is(value.card)
 	}
 	export async function verify(token: authly.Token): Promise<Token & authly.Payload | undefined> {

--- a/Card/Token.ts
+++ b/Card/Token.ts
@@ -2,14 +2,14 @@ import * as authly from "authly"
 import { verify as verifyToken } from "../verify"
 
 export interface Token {
-	type: "authorization" | "recurring"
+	type: "single_use" | "recurring"
 	card: authly.Identifier
 }
 
 export namespace Token {
 	export function is(value: Token | any): value is Token {
 		return typeof value == "object" &&
-			(value.type == "authorization" || value.type == "recurring") &&
+			(value.type == "single_use" || value.type == "recurring") &&
 			authly.Identifier.is(value.card)
 	}
 	export async function verify(token: authly.Token): Promise<Token & authly.Payload | undefined> {


### PR DESCRIPTION
## Change
Renaming card.Token.type "authorization" to "single use" to further point out that it is a temporary token can only be used for one authorization.

## Rationale
Clarification.

## Impact
Only a type name, so none.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
