### PR TITLE
remade to make payfunc inheritance easier

### DIFF
--- a/Merchant/Configuration/Card.ts
+++ b/Merchant/Configuration/Card.ts
@@ -1,10 +1,10 @@
 import * as isoly from "isoly"
 import * as gracely from "gracely"
-import { Acquirer } from "../Acquirer"
-import { CategoryCode } from "./CategoryCode"
-import { Emv3d } from "./Emv3d"
+import { Acquirer } from "../../Acquirer"
+import { CategoryCode } from "../CategoryCode"
+import { Emv3d } from "../Emv3d"
 
-export interface Configuration {
+export interface Card {
 	descriptor?: string
 	country: isoly.CountryCode.Alpha2
 	acquirer: Acquirer
@@ -12,8 +12,8 @@ export interface Configuration {
 	mcc?: CategoryCode,
 	emv3d?: Emv3d,
 }
-export namespace Configuration {
-	export function is(value: Configuration | any): value is Configuration {
+export namespace Card {
+	export function is(value: Card | any): value is Card {
 		return typeof value == "object" &&
 			(value.descriptor == undefined || typeof value.descriptor == "string") &&
 			isoly.CountryCode.Alpha2.is(value.country) &&
@@ -22,10 +22,10 @@ export namespace Configuration {
 			(value.mcc == undefined || CategoryCode.is(value.mcc)) &&
 			(value.emv3d == undefined || Emv3d.is(value.emv3d))
 	}
-	export function flaw(value: any | Configuration): gracely.Flaw {
+	export function flaw(value: any | Card): gracely.Flaw {
 		return {
-			type: "model.Merchant.Configuration",
-			flaws: typeof(value) != "object" ? undefined :
+			type: "model.Merchant.Configuration.Card",
+			flaws: typeof value != "object" ? undefined :
 				[
 					(value.descriptor == undefined || typeof value.descriptor  == "string") || { property: "descriptor", type: "string" },
 					isoly.CountryCode.Alpha2.is(value.country) || { property: "country", type: "isoly.CountryCode" },

--- a/Merchant/Configuration/Override.ts
+++ b/Merchant/Configuration/Override.ts
@@ -1,0 +1,26 @@
+import * as authly from "authly"
+import * as gracely from "gracely"
+
+export interface Override {
+	url: string
+	id?: string
+}
+
+// tslint:disable: no-shadowed-variable
+export namespace Override {
+	export function is(value: any | Override): value is Override {
+		return typeof value == "object" &&
+			typeof value.url == "string" &&
+			(value.id == undefined || authly.Identifier.is(value.id))
+	}
+	export function flaw(value: any | Override): gracely.Flaw {
+		return {
+			type: "model.Merchant.Configuration.Override",
+			flaws: typeof value != "object" ? undefined :
+				[
+					typeof value.url == "string" || { property: "url", type: "string" },
+					value.id == undefined || authly.Identifier.is(value.id) || { property: "id", type: "string | undefined" },
+				].filter(gracely.Flaw.is) as gracely.Flaw[],
+		}
+	}
+}

--- a/Merchant/Configuration/index.spec.ts
+++ b/Merchant/Configuration/index.spec.ts
@@ -1,0 +1,33 @@
+import * as model from "../../index"
+
+describe("model.Merchant.Configuration", () => {
+	it("flaws of very faulty configuration", () => {
+		const configuration = {
+			descriptor: 123,
+			country: "alpha3",
+			acquirer: 123,
+			mid: 1234556789,
+			mcc: 1234556789,
+			emv3d: "Emv3d",
+			url: 123,
+			id: 123,
+		}
+		expect(model.Merchant.Configuration.flaw(configuration)).toEqual({
+			type: 'model.Merchant.Configuration',
+			flaws: [
+				{ property: 'descriptor', type: 'string' },
+				{ property: 'country', type: 'isoly.CountryCode' },
+				{ property: 'acquirer', type: 'model.Acquirer.Settings' },
+				{ property: 'mid', type: 'string' },
+				{ property: 'mcc', type: 'model.Merchant.CategoryCode' },
+				{
+					property: 'emv3d',
+					type: 'model.Merchant.Emv3d',
+					flaws: undefined
+				},
+				{ property: 'url', type: 'string' },
+				{ property: 'id', type: 'string | undefined' }
+			]
+		})
+	})
+})

--- a/Merchant/Configuration/index.ts
+++ b/Merchant/Configuration/index.ts
@@ -1,0 +1,34 @@
+import * as gracely from "gracely"
+import { Card as CCard } from "./Card"
+import { Override as COverride } from "./Override"
+
+export type Configuration = CCard & COverride
+
+export namespace Configuration {
+	export function is(value: Configuration | any): value is Configuration {
+		return typeof value == "object" &&
+			CCard.is(value) &&
+			COverride.is(value)
+	}
+	export function flaw(value: any | Configuration): gracely.Flaw {
+		return {
+			type: "model.Merchant.Configuration",
+			flaws: typeof value != "object" ? undefined :
+				[
+					...(CCard.flaw(value).flaws ?? []),
+					...(COverride.flaw(value).flaws ?? []),
+				].filter(gracely.Flaw.is) as gracely.Flaw[],
+		}
+	}
+	// tslint:disable: no-shadowed-variable
+	export type Card = CCard
+	export namespace Card {
+		export const is = CCard.is
+		export const flaw = CCard.flaw
+	}
+	export type Override = COverride
+	export namespace Override {
+		export const is = COverride.is
+		export const flaw = COverride.flaw
+	}
+}

--- a/Merchant/Key.spec.ts
+++ b/Merchant/Key.spec.ts
@@ -1,0 +1,40 @@
+import * as model from "../index"
+
+describe("Key", () => {
+	const key: model.Merchant.Key = {
+		aud: "public",
+		card: {
+			url: "http://localhost:7082",
+			id: "test",
+			acquirer: {
+				protocol: "clearhaus",
+				url: "https://gateway.test.clearhaus.com",
+				key: "123456-123456-123456",
+			},
+			country: "SE",
+			emv3d: {
+				protocol: "ch3d1",
+				url: "http://localhost:7082/ch3d1sim",
+				key: "no-key",
+			},
+			mcc: "1234",
+			mid: "1234",
+		},
+		iat: 1583504003495,
+		iss: "http://localhost:7082",
+		name: "Test AB",
+		sub: "test",
+		url: "http://example.com",
+	}
+	it("is", () => expect(model.Merchant.Key.is(key)).toBeTruthy())
+	it("is 2", () => {
+		expect(model.Merchant.Key.is(key)).toBeTruthy()
+	})
+	it("is missing id name", () => expect(model.Merchant.Key.is({ country: "GB", acquirer: { protocol: "clearhaus", url: "https://example.com/", key: "secret-api-key" }, mcc: "1234", bin: { visa: "1234", mastercard: "54321" } })).toBeFalsy())
+	it("flaw", () => {
+		expect(model.Merchant.Key.flaw(key)).toEqual({
+			flaws: [],
+			type: "model.Merchant.Key",
+		})
+	})
+})

--- a/Merchant/Key.ts
+++ b/Merchant/Key.ts
@@ -10,10 +10,7 @@ export interface Key {
 	iat: number
 	name: string
 	url: string
-	card: Configuration & {
-		url: string
-		id?: string
-	}
+	card: Configuration
 }
 
 export namespace Key {
@@ -25,13 +22,11 @@ export namespace Key {
 			typeof value.iat == "number" &&
 			typeof value.name == "string" &&
 			typeof value.url == "string" &&
-			Configuration.is(value.card) &&
-			typeof value.card.url == "string" &&
-			(value.card.id == undefined || authly.Identifier.is(value.card.id))
+			Configuration.is(value.card)
 	}
 	export function flaw(value: any | Key): gracely.Flaw {
 		return {
-			type: "model.Key",
+			type: "model.Merchant.Key",
 			flaws: typeof value != "object" ? undefined :
 				[
 					typeof value.sub == "string" || { property: "sub", type: "authly.Identifier", condition: "Merchant identifier." },
@@ -40,11 +35,7 @@ export namespace Key {
 					typeof value.iat == "number" || { property: "iat", type: "number", condition: "Issued timestamp." },
 					typeof value.name == "string" || { property: "name", type: "string" },
 					typeof value.url == "string" || { property: "url", type: "string" },
-					(Configuration.is(value.card) && typeof value.card.url == "string" && (value.card.id == undefined || authly.Identifier.is(value.card.id))) || { property: "card", type: "Key.Configuration & { url: string, id?: string }", flaws: [
-						...(Configuration.flaw(value.card).flaws ?? []),
-						typeof value.card.url == "string" || { property: "url", type: "string" },
-						value.card.id == undefined || authly.Identifier.is(value.card.id) || { property: "id", type: "string | undefined" },
-					] },
+					...(Configuration.flaw(value.card).flaws ?? [{ property: "card", type: "model.Merchant.Configuration", flaws: undefined }]),
 				].filter(gracely.Flaw.is) as gracely.Flaw[],
 		}
 	}

--- a/Merchant/index.spec.ts
+++ b/Merchant/index.spec.ts
@@ -1,26 +1,27 @@
 import * as model from "../index"
 
 describe("Merchant", () => {
-	const merchant = {
-		id: "par9",
-		name: "test",
-		url: "http://example.com",
+	const merchant: model.Merchant = {
 		card: {
-			url: "https://api.cardfunc.com",
-			descriptor: "test transaction",
-			country: "SE",
+			url: "http://localhost:7082",
+			id: "test",
 			acquirer: {
 				protocol: "clearhaus",
 				url: "https://gateway.test.clearhaus.com",
 				key: "36e74a69-7fee-4a37-bcd9-6a1422028ff3",
 			},
+			country: "SE",
+			emv3d: {
+				protocol: "ch3d1",
+				url: "http://localhost:7082/ch3d1sim",
+				key: "no-key",
+			},
 			mcc: "1234",
 			mid: "1234",
-			bin: {
-				mastercard: "134678",
-				visa: "1234",
-			},
 		},
+		name: "Test AB",
+		id: "test",
+		url: "http://example.com",
 	}
 	it("is", () => {
 		expect(model.Merchant.is(merchant)).toBeTruthy()
@@ -32,6 +33,22 @@ describe("Merchant", () => {
 				{ property: "url", type: "string" },
 			],
 			type: "model.Merchant",
+		})
+	})
+	it("flaw of {} as a merchant", () => {
+		console.log("model.Merchant.flaw(merchant): ", model.Merchant.flaw({}))
+		expect(model.Merchant.flaw({})).toEqual({
+			type: 'model.Merchant',
+			flaws: [
+				{ property: 'id', type: 'authly.Identifier' },
+				{ property: 'name', type: 'string' },
+				{ property: 'url', type: 'string' },
+				{
+					property: 'card',
+					type: 'model.Merchant.Configuration',
+					flaws: undefined
+				}
+			]
 		})
 	})
 })

--- a/Merchant/index.ts
+++ b/Merchant/index.ts
@@ -2,16 +2,13 @@ import * as gracely from "gracely"
 import * as authly from "authly"
 import { Key as MerchantKey } from "./Key"
 import * as MerchantV1 from "./V1"
-import { Configuration } from "./Configuration"
+import { Configuration as CConfiguration } from "./Configuration"
 
 export interface Merchant {
 	id: authly.Identifier
 	name: string
 	url: string
-	card: Configuration & {
-		url: string
-		id?: string
-	}
+	card: CConfiguration
 }
 
 // tslint:disable: no-shadowed-variable
@@ -21,7 +18,7 @@ export namespace Merchant {
 			authly.Identifier.is((value as any).id) &&
 			typeof value.name == "string" &&
 			typeof value.url == "string" &&
-			Configuration.is(value.card) &&
+			CConfiguration.is(value.card) &&
 			typeof value.card.url == "string" &&
 			(value.card.id == undefined || authly.Identifier.is(value.card.id))
 	}
@@ -33,12 +30,23 @@ export namespace Merchant {
 					authly.Identifier.is((value as any).id) || { property: "id", type: "authly.Identifier" },
 					typeof value.name == "string" || { property: "name", type: "string" },
 					typeof value.url == "string" || { property: "url", type: "string" },
-					(Configuration.is(value.card) && typeof value.card.url == "string" && (value.card.id == undefined || authly.Identifier.is(value.card.id))) || { property: "card", type: "Merchant.Configuration & { url: string, id?: string }", flaws: [
-						...(Configuration.flaw(value.card).flaws ?? []),
-						typeof value.card.url == "string" || { property: "url", type: "string" },
-						value.card.id == undefined || authly.Identifier.is(value.card.id) || { property: "id", type: "string | undefined" },
-					] },
+					...(CConfiguration.flaw(value.card).flaws ?? [{ property: "card", type: "model.Merchant.Configuration", flaws: undefined }]),
 				].filter(gracely.Flaw.is) as gracely.Flaw[],
+		}
+	}
+	export type Configuration = CConfiguration
+	export namespace Configuration {
+		export const is = CConfiguration.is
+		export const flaw = CConfiguration.flaw
+		export type Card = CConfiguration.Card
+		export namespace Card {
+			export const is = CConfiguration.Card.is
+			export const flaw = CConfiguration.Card.flaw
+		}
+		export type Override = CConfiguration.Override
+		export namespace Override {
+			export const is = CConfiguration.Override.is
+			export const flaw = CConfiguration.Override.flaw
 		}
 	}
 	export type Key = MerchantKey


### PR DESCRIPTION
## Change
Changed previous type model.Merchant.Configuration & { url: string, id?: string } to more easy to use types.

## Rationale
Need to inherit type model.Merchant.Configuration & { url: string, id?: string } elsewhere, so a simpler and clearer typing makes it easier to type check.

## Impact
Same functionality.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
