### PR TITLE
Token info

### DIFF
--- a/Card/Token.spec.ts
+++ b/Card/Token.spec.ts
@@ -1,0 +1,44 @@
+import * as model from "../index"
+
+describe("Card Token", () => {
+	it("is minimal", async () => {
+		const card: model.Card.Token = {
+			type: "single use",
+			card: "12345678"
+		}
+		expect(model.Card.Token.hasInfo(card)).toBeFalsy()
+		expect(model.Card.Token.is(card)).toBeTruthy()
+	})
+	it("has info", async () => {
+		const card: model.Card.Token = {
+			type: "single use",
+			card: "12345678",
+			scheme: "visa",
+			iin: "411111",
+			last4: "1111",
+			expires: [12, 26],
+		}
+		expect(model.Card.Token.hasInfo(card)).toBeTruthy()
+		expect(model.Card.Token.is(card)).toBeTruthy()
+	})
+	it("is minimal", async () => {
+		const card: model.Card.Token = {
+			type: "single use",
+			card: "12345678"
+		}
+		expect(model.Card.Token.hasInfo(card)).toBeFalsy()
+		expect(model.Card.Token.is(card)).toBeTruthy()
+	})
+	it("has info", async () => {
+		const card: model.Card.Token = {
+			type: "single use",
+			card: "12345678",
+			scheme: "visa",
+			iin: "411111",
+			last4: "1111",
+			expires: [12, 26],
+		}
+		expect(model.Card.Token.hasInfo(card)).toBeTruthy()
+		expect(model.Card.Token.is(card)).toBeTruthy()
+	})
+})

--- a/Card/Token.spec.ts
+++ b/Card/Token.spec.ts
@@ -41,4 +41,26 @@ describe("Card Token", () => {
 		expect(model.Card.Token.hasInfo(card)).toBeTruthy()
 		expect(model.Card.Token.is(card)).toBeTruthy()
 	})
+	it("Verifying tokens signed in backend", async () => {
+		const originalMinimalToken: model.Card.Token = {
+			type: "single use",
+			card: "12345678",
+		}
+		const minimalToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjYXJkZnVuYyIsImlhdCI6MTU5NTYwNDg5OTI0NiwiYXVkIjoiZGV2ZWxvcG1lbnQiLCJ0eXBlIjoic2luZ2xlIHVzZSIsImNhcmQiOiIxMjM0NTY3OCJ9.CW70uwZlIHh44hDeRZOCmPhzdGnFMFxjuDJayF16iDtMhOxuA9Xwvr8r5rJ7FYVJhrljyp87ntDSfJYMd2KJp9vA--AO6By7dDuk6REejT70AZnLiy3u8fMzT9gmKZYBZQPIID1HaGqwxX4yjcwoczavTQSaX0kgONibWe-UZ4ExWYqapgh4t7DfYLQrrgVqbHKUnuaqGr-5ehHhjtyglEySUH7UeexwqlHKR5updiqTe2wz61FHi2nBiZW_JvZVDAZbRkbci9J00fCWl3vl6VbIW9bGymfYSr3KXVfdEVaM1K1PPNsD8G5e0fJgwDm15JjJhGvkXqiFTXRM1cScdg"
+		const verifiedMinimalToken = await model.Card.Token.verify(minimalToken)
+		const payloadedMinimalToken = verifiedMinimalToken && { ...originalMinimalToken, aud: verifiedMinimalToken.aud, iss: verifiedMinimalToken.iss, iat: verifiedMinimalToken.iat }
+		expect(verifiedMinimalToken).toEqual(payloadedMinimalToken)
+		const originalTokenWithInfo: model.Card.Token = {
+			type: "single use",
+			card: "12345678",
+			scheme: "visa",
+			iin: "411111",
+			last4: "1111",
+			expires: [12, 26],
+		}
+		const tokenWithInfo = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJjYXJkZnVuYyIsImlhdCI6MTU5NTYwNDg5OTI2OSwiYXVkIjoiZGV2ZWxvcG1lbnQiLCJ0eXBlIjoic2luZ2xlIHVzZSIsImNhcmQiOiIxMjM0NTY3OCIsInNjaGVtZSI6InZpc2EiLCJpaW4iOiI0MTExMTEiLCJsYXN0NCI6IjExMTEiLCJleHBpcmVzIjpbMTIsMjZdfQ.JMA2FYtK8EVp2nV1BnLFoM1k2Cz8XTZEABBH7ZwGtfrp7sURb9QQPgXiO_luM4bRtqyVgtAUOxdp-KKS1IHGFmhga-9nh94Piv1qoR9XROSI9YJFn71N5m7x8qWZYh874KLEwrXWZge4WP1n1K_MtiEmzZw_yq1InOKaYqhfF3XMb1dTx0-k37_2RfKHLXPYuEdVy5ygRHONt2BcNsMkmV1Nh1YZ4ktPbAHynYWlqKEp1eLjJpMoSN7wLecZHLkzSenCHEDHLxVayqJBR48TxB3PV23CzqqEWlvg7EVY3io5lAiUJyXanAUCOF6lPlbNjR-BLQ2BmzcjJLEefxXqXA"
+		const verifiedWithInfo = await model.Card.Token.verify(tokenWithInfo)
+		const withInfoPayloaded = verifiedWithInfo && { ...originalTokenWithInfo, aud: verifiedWithInfo.aud, iss: verifiedWithInfo.iss, iat: verifiedWithInfo.iat }
+		expect(verifiedWithInfo).toEqual(withInfoPayloaded)
+	})
 })

--- a/Card/Token.ts
+++ b/Card/Token.ts
@@ -6,10 +6,10 @@ import { Expires } from "./Expires"
 export interface Token {
 	type: "single use" | "recurring"
 	card: authly.Identifier
-	scheme: Scheme
-	iin: string
-	last4: string
-	expires: Expires
+	scheme?: Scheme
+	iin?: string
+	last4?: string
+	expires?: Expires
 }
 
 export namespace Token {
@@ -17,6 +17,13 @@ export namespace Token {
 		return typeof value == "object" &&
 			(value.type == "single use" || value.type == "recurring") &&
 			authly.Identifier.is(value.card) &&
+			(value.scheme == undefined || Scheme.is(value.scheme)) &&
+			(value.iin == undefined || typeof value.iin == "string" && value.iin.length == 6) &&
+			(value.last4 == undefined || typeof value.last4 == "string" && value.last4.length == 4) &&
+			(value.expires == undefined || Expires.is(value.expires))
+	}
+	export function hasInfo(value: Token | any): value is Token & { scheme: Scheme, iin: string, last4: string, expires: Expires } {
+		return is(value) &&
 			Scheme.is(value.scheme) &&
 			typeof value.iin == "string" && value.iin.length == 6 &&
 			typeof value.last4 == "string" && value.last4.length == 4 &&

--- a/Card/Token.ts
+++ b/Card/Token.ts
@@ -1,16 +1,26 @@
 import * as authly from "authly"
 import { verify as verifyToken } from "../verify"
+import { Scheme } from "./Scheme"
+import { Expires } from "./Expires"
 
 export interface Token {
 	type: "single use" | "recurring"
 	card: authly.Identifier
+	scheme: Scheme
+	iin: string
+	last4: string
+	expires: Expires
 }
 
 export namespace Token {
 	export function is(value: Token | any): value is Token {
 		return typeof value == "object" &&
 			(value.type == "single use" || value.type == "recurring") &&
-			authly.Identifier.is(value.card)
+			authly.Identifier.is(value.card) &&
+			Scheme.is(value.scheme) &&
+			typeof value.iin == "string" && value.iin.length == 6 &&
+			typeof value.last4 == "string" && value.last4.length == 4 &&
+			Expires.is(value.expires)
 	}
 	export async function verify(token: authly.Token): Promise<Token & authly.Payload | undefined> {
 		const result = await verifyToken(token)

--- a/Card/index.spec.ts
+++ b/Card/index.spec.ts
@@ -19,11 +19,31 @@ describe("Card", () => {
 			expires: [2, 22],
 			csc: "123",
 		}
-		expect(model.Card.from(card)).toEqual({
+		const complete: Omit<model.Card, "id" | "reference"> = model.Card.from(card)
+		expect(complete).toEqual({
 			scheme: "mastercard",
 			iin: "510510",
 			last4: "5100",
 			expires: [2, 22],
 		})
+		const partialCard: model.Card.Change = {
+			pan: "5105105105105100",
+		}
+		const partial: Omit<Partial<model.Card>, "id" | "reference"> = model.Card.from(partialCard)
+		expect(partial).toEqual({
+			scheme: "mastercard",
+			iin: "510510",
+			last4: "5100",
+		})
+		const expiresOnly: model.Card.Change = {
+			expires: [2, 22],
+		}
+		const expiresOnlyOutput: Omit<Partial<model.Card>, "id" | "reference"> = model.Card.from(expiresOnly)
+		expect(expiresOnlyOutput).toEqual({
+			expires: [2, 22],
+		})
+		const emptyCard: model.Card.Change = {}
+		const emptyCardOutput: Omit<Partial<model.Card>, "id" | "reference"> = model.Card.from(emptyCard)
+		expect(emptyCardOutput).toEqual({})
 	})
 })

--- a/Card/index.ts
+++ b/Card/index.ts
@@ -31,13 +31,31 @@ export namespace Card {
 			CardExpires.is(value.expires) &&
 			(value.type == undefined || CardType.is(value.type))
 	}
-	export function from(value: CardCreatable): Omit<Card, "id" | "reference"> {
-		return {
-			scheme: CardPan.scheme(value.pan),
-			iin: CardPan.iin(value.pan),
-			last4: CardPan.last4(value.pan),
-			expires: value.expires,
+	export function from(value: CardCreatable): Omit<Card, "id" | "reference">
+	export function from(value: Change): Omit<Partial<Card>, "id" | "reference">
+	export function from(value: CardCreatable | Change): Omit<Card, "id" | "reference"> | Omit<Partial<Card>, "id" | "reference"> {
+		let result: Omit<Card, "id" | "reference"> | Omit<Partial<Card>, "id" | "reference">
+		if (CardCreatable.is(value))
+			result = {
+				scheme: CardPan.scheme(value.pan),
+				iin: CardPan.iin(value.pan),
+				last4: CardPan.last4(value.pan),
+				expires: value.expires,
+			}
+		else {
+			result = {}
+			if (value.pan) {
+				result = {
+					...result,
+					scheme: Pan.scheme(value.pan),
+					iin: Pan.iin(value.pan),
+					last4: Pan.last4(value.pan),
+				}
+			}
+			if (value.expires)
+				result = { ...result, expires: value.expires }
 		}
+		return result
 	}
 	export function generateId(): authly.Identifier {
 		return authly.Identifier.generate(8)

--- a/Card/index.ts
+++ b/Card/index.ts
@@ -99,6 +99,7 @@ export namespace Card {
 	export type Token = CardToken
 	export namespace Token {
 		export const is = CardToken.is
+		export const hasInfo = CardToken.hasInfo
 		export const verify = CardToken.verify
 	}
 }


### PR DESCRIPTION
## Change
Adding minimal safe card information to tokens for storing such info in order database for quick reference.

## Rationale
To have access to some card information when matching authorizations and orders.

## Impact
Same information is already available, but api changes slightly and this information will be needed, but no major differences in what is stored and sent compared to before. No sensitive card information will be sent from cardfunc.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
