### PR TITLE
Changed babel-core to @babel/core because of lodash security issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,29 +14,175 @@
    }
   },
   "@babel/core": {
-   "version": "7.10.2",
-   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.2.tgz",
-   "integrity": "sha512-KQmV9yguEjQsXqyOUGKjS4+3K8/DlOCE2pZcq4augdQmtTy5iv5EHtmMSJ7V4c1BIPjuwtZYqYLCq9Ga+hGBRQ==",
+   "version": "7.11.0",
+   "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.0.tgz",
+   "integrity": "sha512-mkLq8nwaXmDtFmRkQ8ED/eA2CnVw4zr7dCztKalZXBvdK5EeNUAesrrwUqjQEzFgomJssayzB0aqlOsP1vGLqg==",
    "dev": true,
    "requires": {
-    "@babel/code-frame": "^7.10.1",
-    "@babel/generator": "^7.10.2",
-    "@babel/helper-module-transforms": "^7.10.1",
-    "@babel/helpers": "^7.10.1",
-    "@babel/parser": "^7.10.2",
-    "@babel/template": "^7.10.1",
-    "@babel/traverse": "^7.10.1",
-    "@babel/types": "^7.10.2",
+    "@babel/code-frame": "^7.10.4",
+    "@babel/generator": "^7.11.0",
+    "@babel/helper-module-transforms": "^7.11.0",
+    "@babel/helpers": "^7.10.4",
+    "@babel/parser": "^7.11.0",
+    "@babel/template": "^7.10.4",
+    "@babel/traverse": "^7.11.0",
+    "@babel/types": "^7.11.0",
     "convert-source-map": "^1.7.0",
     "debug": "^4.1.0",
     "gensync": "^1.0.0-beta.1",
     "json5": "^2.1.2",
-    "lodash": "^4.17.13",
+    "lodash": "^4.17.19",
     "resolve": "^1.3.2",
     "semver": "^5.4.1",
     "source-map": "^0.5.0"
    },
    "dependencies": {
+    "@babel/code-frame": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+     "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+     "dev": true,
+     "requires": {
+      "@babel/highlight": "^7.10.4"
+     }
+    },
+    "@babel/generator": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+     "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.11.0",
+      "jsesc": "^2.5.1",
+      "source-map": "^0.5.0"
+     }
+    },
+    "@babel/helper-function-name": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+     "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-get-function-arity": "^7.10.4",
+      "@babel/template": "^7.10.4",
+      "@babel/types": "^7.10.4"
+     }
+    },
+    "@babel/helper-get-function-arity": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+     "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.10.4"
+     }
+    },
+    "@babel/helper-split-export-declaration": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+     "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.11.0"
+     }
+    },
+    "@babel/helper-validator-identifier": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+     "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+     "dev": true
+    },
+    "@babel/highlight": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+     "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "chalk": "^2.0.0",
+      "js-tokens": "^4.0.0"
+     }
+    },
+    "@babel/parser": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
+     "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==",
+     "dev": true
+    },
+    "@babel/template": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+     "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+     "dev": true,
+     "requires": {
+      "@babel/code-frame": "^7.10.4",
+      "@babel/parser": "^7.10.4",
+      "@babel/types": "^7.10.4"
+     }
+    },
+    "@babel/traverse": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+     "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+     "dev": true,
+     "requires": {
+      "@babel/code-frame": "^7.10.4",
+      "@babel/generator": "^7.11.0",
+      "@babel/helper-function-name": "^7.10.4",
+      "@babel/helper-split-export-declaration": "^7.11.0",
+      "@babel/parser": "^7.11.0",
+      "@babel/types": "^7.11.0",
+      "debug": "^4.1.0",
+      "globals": "^11.1.0",
+      "lodash": "^4.17.19"
+     }
+    },
+    "@babel/types": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+     "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "lodash": "^4.17.19",
+      "to-fast-properties": "^2.0.0"
+     }
+    },
+    "ansi-styles": {
+     "version": "3.2.1",
+     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+     "dev": true,
+     "requires": {
+      "color-convert": "^1.9.0"
+     }
+    },
+    "chalk": {
+     "version": "2.4.2",
+     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+     "dev": true,
+     "requires": {
+      "ansi-styles": "^3.2.1",
+      "escape-string-regexp": "^1.0.5",
+      "supports-color": "^5.3.0"
+     }
+    },
+    "color-convert": {
+     "version": "1.9.3",
+     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+     "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+     "dev": true,
+     "requires": {
+      "color-name": "1.1.3"
+     }
+    },
+    "color-name": {
+     "version": "1.1.3",
+     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+     "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+     "dev": true
+    },
     "convert-source-map": {
      "version": "1.7.0",
      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -55,6 +201,30 @@
       "ms": "^2.1.1"
      }
     },
+    "globals": {
+     "version": "11.12.0",
+     "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+     "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+     "dev": true
+    },
+    "has-flag": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+     "dev": true
+    },
+    "js-tokens": {
+     "version": "4.0.0",
+     "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+     "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+     "dev": true
+    },
+    "jsesc": {
+     "version": "2.5.2",
+     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+     "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+     "dev": true
+    },
     "json5": {
      "version": "2.1.3",
      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
@@ -64,16 +234,31 @@
       "minimist": "^1.2.5"
      }
     },
-    "minimist": {
-     "version": "1.2.5",
-     "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-     "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+    "lodash": {
+     "version": "4.17.19",
+     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+     "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
      "dev": true
     },
     "ms": {
      "version": "2.1.2",
      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+     "dev": true
+    },
+    "supports-color": {
+     "version": "5.5.0",
+     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+     "dev": true,
+     "requires": {
+      "has-flag": "^3.0.0"
+     }
+    },
+    "to-fast-properties": {
+     "version": "2.0.0",
+     "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+     "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
      "dev": true
     }
    }
@@ -119,45 +304,271 @@
    }
   },
   "@babel/helper-member-expression-to-functions": {
-   "version": "7.10.1",
-   "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
-   "integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
+   "version": "7.11.0",
+   "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+   "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
    "dev": true,
    "requires": {
-    "@babel/types": "^7.10.1"
+    "@babel/types": "^7.11.0"
+   },
+   "dependencies": {
+    "@babel/helper-validator-identifier": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+     "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+     "dev": true
+    },
+    "@babel/types": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+     "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "lodash": "^4.17.19",
+      "to-fast-properties": "^2.0.0"
+     }
+    },
+    "lodash": {
+     "version": "4.17.19",
+     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+     "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+     "dev": true
+    },
+    "to-fast-properties": {
+     "version": "2.0.0",
+     "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+     "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+     "dev": true
+    }
    }
   },
   "@babel/helper-module-imports": {
-   "version": "7.10.1",
-   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
-   "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+   "version": "7.10.4",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+   "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
    "dev": true,
    "requires": {
-    "@babel/types": "^7.10.1"
+    "@babel/types": "^7.10.4"
+   },
+   "dependencies": {
+    "@babel/helper-validator-identifier": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+     "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+     "dev": true
+    },
+    "@babel/types": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+     "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "lodash": "^4.17.19",
+      "to-fast-properties": "^2.0.0"
+     }
+    },
+    "lodash": {
+     "version": "4.17.19",
+     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+     "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+     "dev": true
+    },
+    "to-fast-properties": {
+     "version": "2.0.0",
+     "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+     "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+     "dev": true
+    }
    }
   },
   "@babel/helper-module-transforms": {
-   "version": "7.10.1",
-   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
-   "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
+   "version": "7.11.0",
+   "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+   "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
    "dev": true,
    "requires": {
-    "@babel/helper-module-imports": "^7.10.1",
-    "@babel/helper-replace-supers": "^7.10.1",
-    "@babel/helper-simple-access": "^7.10.1",
-    "@babel/helper-split-export-declaration": "^7.10.1",
-    "@babel/template": "^7.10.1",
-    "@babel/types": "^7.10.1",
-    "lodash": "^4.17.13"
+    "@babel/helper-module-imports": "^7.10.4",
+    "@babel/helper-replace-supers": "^7.10.4",
+    "@babel/helper-simple-access": "^7.10.4",
+    "@babel/helper-split-export-declaration": "^7.11.0",
+    "@babel/template": "^7.10.4",
+    "@babel/types": "^7.11.0",
+    "lodash": "^4.17.19"
+   },
+   "dependencies": {
+    "@babel/code-frame": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+     "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+     "dev": true,
+     "requires": {
+      "@babel/highlight": "^7.10.4"
+     }
+    },
+    "@babel/helper-split-export-declaration": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+     "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.11.0"
+     }
+    },
+    "@babel/helper-validator-identifier": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+     "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+     "dev": true
+    },
+    "@babel/highlight": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+     "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "chalk": "^2.0.0",
+      "js-tokens": "^4.0.0"
+     }
+    },
+    "@babel/parser": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
+     "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==",
+     "dev": true
+    },
+    "@babel/template": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+     "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+     "dev": true,
+     "requires": {
+      "@babel/code-frame": "^7.10.4",
+      "@babel/parser": "^7.10.4",
+      "@babel/types": "^7.10.4"
+     }
+    },
+    "@babel/types": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+     "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "lodash": "^4.17.19",
+      "to-fast-properties": "^2.0.0"
+     }
+    },
+    "ansi-styles": {
+     "version": "3.2.1",
+     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+     "dev": true,
+     "requires": {
+      "color-convert": "^1.9.0"
+     }
+    },
+    "chalk": {
+     "version": "2.4.2",
+     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+     "dev": true,
+     "requires": {
+      "ansi-styles": "^3.2.1",
+      "escape-string-regexp": "^1.0.5",
+      "supports-color": "^5.3.0"
+     }
+    },
+    "color-convert": {
+     "version": "1.9.3",
+     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+     "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+     "dev": true,
+     "requires": {
+      "color-name": "1.1.3"
+     }
+    },
+    "color-name": {
+     "version": "1.1.3",
+     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+     "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+     "dev": true
+    },
+    "has-flag": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+     "dev": true
+    },
+    "js-tokens": {
+     "version": "4.0.0",
+     "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+     "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+     "dev": true
+    },
+    "lodash": {
+     "version": "4.17.19",
+     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+     "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+     "dev": true
+    },
+    "supports-color": {
+     "version": "5.5.0",
+     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+     "dev": true,
+     "requires": {
+      "has-flag": "^3.0.0"
+     }
+    },
+    "to-fast-properties": {
+     "version": "2.0.0",
+     "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+     "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+     "dev": true
+    }
    }
   },
   "@babel/helper-optimise-call-expression": {
-   "version": "7.10.1",
-   "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
-   "integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
+   "version": "7.10.4",
+   "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+   "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
    "dev": true,
    "requires": {
-    "@babel/types": "^7.10.1"
+    "@babel/types": "^7.10.4"
+   },
+   "dependencies": {
+    "@babel/helper-validator-identifier": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+     "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+     "dev": true
+    },
+    "@babel/types": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+     "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "lodash": "^4.17.19",
+      "to-fast-properties": "^2.0.0"
+     }
+    },
+    "lodash": {
+     "version": "4.17.19",
+     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+     "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+     "dev": true
+    },
+    "to-fast-properties": {
+     "version": "2.0.0",
+     "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+     "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+     "dev": true
+    }
    }
   },
   "@babel/helper-plugin-utils": {
@@ -167,25 +578,357 @@
    "dev": true
   },
   "@babel/helper-replace-supers": {
-   "version": "7.10.1",
-   "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
-   "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
+   "version": "7.10.4",
+   "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+   "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
    "dev": true,
    "requires": {
-    "@babel/helper-member-expression-to-functions": "^7.10.1",
-    "@babel/helper-optimise-call-expression": "^7.10.1",
-    "@babel/traverse": "^7.10.1",
-    "@babel/types": "^7.10.1"
+    "@babel/helper-member-expression-to-functions": "^7.10.4",
+    "@babel/helper-optimise-call-expression": "^7.10.4",
+    "@babel/traverse": "^7.10.4",
+    "@babel/types": "^7.10.4"
+   },
+   "dependencies": {
+    "@babel/code-frame": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+     "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+     "dev": true,
+     "requires": {
+      "@babel/highlight": "^7.10.4"
+     }
+    },
+    "@babel/generator": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+     "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.11.0",
+      "jsesc": "^2.5.1",
+      "source-map": "^0.5.0"
+     }
+    },
+    "@babel/helper-function-name": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+     "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-get-function-arity": "^7.10.4",
+      "@babel/template": "^7.10.4",
+      "@babel/types": "^7.10.4"
+     }
+    },
+    "@babel/helper-get-function-arity": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+     "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.10.4"
+     }
+    },
+    "@babel/helper-split-export-declaration": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+     "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.11.0"
+     }
+    },
+    "@babel/helper-validator-identifier": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+     "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+     "dev": true
+    },
+    "@babel/highlight": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+     "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "chalk": "^2.0.0",
+      "js-tokens": "^4.0.0"
+     }
+    },
+    "@babel/parser": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
+     "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==",
+     "dev": true
+    },
+    "@babel/template": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+     "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+     "dev": true,
+     "requires": {
+      "@babel/code-frame": "^7.10.4",
+      "@babel/parser": "^7.10.4",
+      "@babel/types": "^7.10.4"
+     }
+    },
+    "@babel/traverse": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+     "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+     "dev": true,
+     "requires": {
+      "@babel/code-frame": "^7.10.4",
+      "@babel/generator": "^7.11.0",
+      "@babel/helper-function-name": "^7.10.4",
+      "@babel/helper-split-export-declaration": "^7.11.0",
+      "@babel/parser": "^7.11.0",
+      "@babel/types": "^7.11.0",
+      "debug": "^4.1.0",
+      "globals": "^11.1.0",
+      "lodash": "^4.17.19"
+     }
+    },
+    "@babel/types": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+     "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "lodash": "^4.17.19",
+      "to-fast-properties": "^2.0.0"
+     }
+    },
+    "ansi-styles": {
+     "version": "3.2.1",
+     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+     "dev": true,
+     "requires": {
+      "color-convert": "^1.9.0"
+     }
+    },
+    "chalk": {
+     "version": "2.4.2",
+     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+     "dev": true,
+     "requires": {
+      "ansi-styles": "^3.2.1",
+      "escape-string-regexp": "^1.0.5",
+      "supports-color": "^5.3.0"
+     }
+    },
+    "color-convert": {
+     "version": "1.9.3",
+     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+     "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+     "dev": true,
+     "requires": {
+      "color-name": "1.1.3"
+     }
+    },
+    "color-name": {
+     "version": "1.1.3",
+     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+     "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+     "dev": true
+    },
+    "debug": {
+     "version": "4.1.1",
+     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+     "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+     "dev": true,
+     "requires": {
+      "ms": "^2.1.1"
+     }
+    },
+    "globals": {
+     "version": "11.12.0",
+     "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+     "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+     "dev": true
+    },
+    "has-flag": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+     "dev": true
+    },
+    "js-tokens": {
+     "version": "4.0.0",
+     "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+     "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+     "dev": true
+    },
+    "jsesc": {
+     "version": "2.5.2",
+     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+     "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+     "dev": true
+    },
+    "lodash": {
+     "version": "4.17.19",
+     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+     "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+     "dev": true
+    },
+    "ms": {
+     "version": "2.1.2",
+     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+     "dev": true
+    },
+    "supports-color": {
+     "version": "5.5.0",
+     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+     "dev": true,
+     "requires": {
+      "has-flag": "^3.0.0"
+     }
+    },
+    "to-fast-properties": {
+     "version": "2.0.0",
+     "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+     "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+     "dev": true
+    }
    }
   },
   "@babel/helper-simple-access": {
-   "version": "7.10.1",
-   "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
-   "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
+   "version": "7.10.4",
+   "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+   "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
    "dev": true,
    "requires": {
-    "@babel/template": "^7.10.1",
-    "@babel/types": "^7.10.1"
+    "@babel/template": "^7.10.4",
+    "@babel/types": "^7.10.4"
+   },
+   "dependencies": {
+    "@babel/code-frame": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+     "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+     "dev": true,
+     "requires": {
+      "@babel/highlight": "^7.10.4"
+     }
+    },
+    "@babel/helper-validator-identifier": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+     "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+     "dev": true
+    },
+    "@babel/highlight": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+     "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "chalk": "^2.0.0",
+      "js-tokens": "^4.0.0"
+     }
+    },
+    "@babel/parser": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
+     "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==",
+     "dev": true
+    },
+    "@babel/template": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+     "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+     "dev": true,
+     "requires": {
+      "@babel/code-frame": "^7.10.4",
+      "@babel/parser": "^7.10.4",
+      "@babel/types": "^7.10.4"
+     }
+    },
+    "@babel/types": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+     "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "lodash": "^4.17.19",
+      "to-fast-properties": "^2.0.0"
+     }
+    },
+    "ansi-styles": {
+     "version": "3.2.1",
+     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+     "dev": true,
+     "requires": {
+      "color-convert": "^1.9.0"
+     }
+    },
+    "chalk": {
+     "version": "2.4.2",
+     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+     "dev": true,
+     "requires": {
+      "ansi-styles": "^3.2.1",
+      "escape-string-regexp": "^1.0.5",
+      "supports-color": "^5.3.0"
+     }
+    },
+    "color-convert": {
+     "version": "1.9.3",
+     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+     "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+     "dev": true,
+     "requires": {
+      "color-name": "1.1.3"
+     }
+    },
+    "color-name": {
+     "version": "1.1.3",
+     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+     "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+     "dev": true
+    },
+    "has-flag": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+     "dev": true
+    },
+    "js-tokens": {
+     "version": "4.0.0",
+     "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+     "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+     "dev": true
+    },
+    "lodash": {
+     "version": "4.17.19",
+     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+     "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+     "dev": true
+    },
+    "supports-color": {
+     "version": "5.5.0",
+     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+     "dev": true,
+     "requires": {
+      "has-flag": "^3.0.0"
+     }
+    },
+    "to-fast-properties": {
+     "version": "2.0.0",
+     "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+     "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+     "dev": true
+    }
    }
   },
   "@babel/helper-split-export-declaration": {
@@ -204,14 +947,222 @@
    "dev": true
   },
   "@babel/helpers": {
-   "version": "7.10.1",
-   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.1.tgz",
-   "integrity": "sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==",
+   "version": "7.10.4",
+   "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
+   "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
    "dev": true,
    "requires": {
-    "@babel/template": "^7.10.1",
-    "@babel/traverse": "^7.10.1",
-    "@babel/types": "^7.10.1"
+    "@babel/template": "^7.10.4",
+    "@babel/traverse": "^7.10.4",
+    "@babel/types": "^7.10.4"
+   },
+   "dependencies": {
+    "@babel/code-frame": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+     "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+     "dev": true,
+     "requires": {
+      "@babel/highlight": "^7.10.4"
+     }
+    },
+    "@babel/generator": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
+     "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.11.0",
+      "jsesc": "^2.5.1",
+      "source-map": "^0.5.0"
+     }
+    },
+    "@babel/helper-function-name": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+     "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-get-function-arity": "^7.10.4",
+      "@babel/template": "^7.10.4",
+      "@babel/types": "^7.10.4"
+     }
+    },
+    "@babel/helper-get-function-arity": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+     "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.10.4"
+     }
+    },
+    "@babel/helper-split-export-declaration": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+     "integrity": "sha512-74Vejvp6mHkGE+m+k5vHY93FX2cAtrw1zXrZXRlG4l410Nm9PxfEiVTn1PjDPV5SnmieiueY4AFg2xqhNFuuZg==",
+     "dev": true,
+     "requires": {
+      "@babel/types": "^7.11.0"
+     }
+    },
+    "@babel/helper-validator-identifier": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+     "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+     "dev": true
+    },
+    "@babel/highlight": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+     "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "chalk": "^2.0.0",
+      "js-tokens": "^4.0.0"
+     }
+    },
+    "@babel/parser": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.0.tgz",
+     "integrity": "sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==",
+     "dev": true
+    },
+    "@babel/template": {
+     "version": "7.10.4",
+     "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+     "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
+     "dev": true,
+     "requires": {
+      "@babel/code-frame": "^7.10.4",
+      "@babel/parser": "^7.10.4",
+      "@babel/types": "^7.10.4"
+     }
+    },
+    "@babel/traverse": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
+     "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+     "dev": true,
+     "requires": {
+      "@babel/code-frame": "^7.10.4",
+      "@babel/generator": "^7.11.0",
+      "@babel/helper-function-name": "^7.10.4",
+      "@babel/helper-split-export-declaration": "^7.11.0",
+      "@babel/parser": "^7.11.0",
+      "@babel/types": "^7.11.0",
+      "debug": "^4.1.0",
+      "globals": "^11.1.0",
+      "lodash": "^4.17.19"
+     }
+    },
+    "@babel/types": {
+     "version": "7.11.0",
+     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
+     "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+     "dev": true,
+     "requires": {
+      "@babel/helper-validator-identifier": "^7.10.4",
+      "lodash": "^4.17.19",
+      "to-fast-properties": "^2.0.0"
+     }
+    },
+    "ansi-styles": {
+     "version": "3.2.1",
+     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+     "dev": true,
+     "requires": {
+      "color-convert": "^1.9.0"
+     }
+    },
+    "chalk": {
+     "version": "2.4.2",
+     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+     "dev": true,
+     "requires": {
+      "ansi-styles": "^3.2.1",
+      "escape-string-regexp": "^1.0.5",
+      "supports-color": "^5.3.0"
+     }
+    },
+    "color-convert": {
+     "version": "1.9.3",
+     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+     "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+     "dev": true,
+     "requires": {
+      "color-name": "1.1.3"
+     }
+    },
+    "color-name": {
+     "version": "1.1.3",
+     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+     "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+     "dev": true
+    },
+    "debug": {
+     "version": "4.1.1",
+     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+     "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+     "dev": true,
+     "requires": {
+      "ms": "^2.1.1"
+     }
+    },
+    "globals": {
+     "version": "11.12.0",
+     "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+     "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+     "dev": true
+    },
+    "has-flag": {
+     "version": "3.0.0",
+     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+     "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+     "dev": true
+    },
+    "js-tokens": {
+     "version": "4.0.0",
+     "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+     "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+     "dev": true
+    },
+    "jsesc": {
+     "version": "2.5.2",
+     "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+     "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+     "dev": true
+    },
+    "lodash": {
+     "version": "4.17.19",
+     "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+     "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+     "dev": true
+    },
+    "ms": {
+     "version": "2.1.2",
+     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+     "dev": true
+    },
+    "supports-color": {
+     "version": "5.5.0",
+     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+     "dev": true,
+     "requires": {
+      "has-flag": "^3.0.0"
+     }
+    },
+    "to-fast-properties": {
+     "version": "2.0.0",
+     "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+     "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+     "dev": true
+    }
    }
   },
   "@babel/highlight": {
@@ -1332,18 +2283,6 @@
     }
    }
   },
-  "ansi-regex": {
-   "version": "2.1.1",
-   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-   "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-   "dev": true
-  },
-  "ansi-styles": {
-   "version": "2.2.1",
-   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-   "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-   "dev": true
-  },
   "anymatch": {
    "version": "3.1.1",
    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
@@ -1456,70 +2395,6 @@
    "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
    "dev": true
   },
-  "babel-code-frame": {
-   "version": "6.26.0",
-   "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-   "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-   "dev": true,
-   "requires": {
-    "chalk": "^1.1.3",
-    "esutils": "^2.0.2",
-    "js-tokens": "^3.0.2"
-   }
-  },
-  "babel-core": {
-   "version": "6.26.3",
-   "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
-   "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-   "dev": true,
-   "requires": {
-    "babel-code-frame": "^6.26.0",
-    "babel-generator": "^6.26.0",
-    "babel-helpers": "^6.24.1",
-    "babel-messages": "^6.23.0",
-    "babel-register": "^6.26.0",
-    "babel-runtime": "^6.26.0",
-    "babel-template": "^6.26.0",
-    "babel-traverse": "^6.26.0",
-    "babel-types": "^6.26.0",
-    "babylon": "^6.18.0",
-    "convert-source-map": "^1.5.1",
-    "debug": "^2.6.9",
-    "json5": "^0.5.1",
-    "lodash": "^4.17.4",
-    "minimatch": "^3.0.4",
-    "path-is-absolute": "^1.0.1",
-    "private": "^0.1.8",
-    "slash": "^1.0.0",
-    "source-map": "^0.5.7"
-   }
-  },
-  "babel-generator": {
-   "version": "6.26.1",
-   "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
-   "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-   "dev": true,
-   "requires": {
-    "babel-messages": "^6.23.0",
-    "babel-runtime": "^6.26.0",
-    "babel-types": "^6.26.0",
-    "detect-indent": "^4.0.0",
-    "jsesc": "^1.3.0",
-    "lodash": "^4.17.4",
-    "source-map": "^0.5.7",
-    "trim-right": "^1.0.1"
-   }
-  },
-  "babel-helpers": {
-   "version": "6.24.1",
-   "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
-   "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-   "dev": true,
-   "requires": {
-    "babel-runtime": "^6.22.0",
-    "babel-template": "^6.24.1"
-   }
-  },
   "babel-jest": {
    "version": "26.0.1",
    "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.0.1.tgz",
@@ -1585,15 +2460,6 @@
     }
    }
   },
-  "babel-messages": {
-   "version": "6.23.0",
-   "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-   "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-   "dev": true,
-   "requires": {
-    "babel-runtime": "^6.22.0"
-   }
-  },
   "babel-plugin-istanbul": {
    "version": "6.0.0",
    "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
@@ -1645,79 +2511,6 @@
     "babel-plugin-jest-hoist": "^26.0.0",
     "babel-preset-current-node-syntax": "^0.1.2"
    }
-  },
-  "babel-register": {
-   "version": "6.26.0",
-   "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
-   "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-   "dev": true,
-   "requires": {
-    "babel-core": "^6.26.0",
-    "babel-runtime": "^6.26.0",
-    "core-js": "^2.5.0",
-    "home-or-tmp": "^2.0.0",
-    "lodash": "^4.17.4",
-    "mkdirp": "^0.5.1",
-    "source-map-support": "^0.4.15"
-   }
-  },
-  "babel-runtime": {
-   "version": "6.26.0",
-   "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-   "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-   "dev": true,
-   "requires": {
-    "core-js": "^2.4.0",
-    "regenerator-runtime": "^0.11.0"
-   }
-  },
-  "babel-template": {
-   "version": "6.26.0",
-   "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-   "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-   "dev": true,
-   "requires": {
-    "babel-runtime": "^6.26.0",
-    "babel-traverse": "^6.26.0",
-    "babel-types": "^6.26.0",
-    "babylon": "^6.18.0",
-    "lodash": "^4.17.4"
-   }
-  },
-  "babel-traverse": {
-   "version": "6.26.0",
-   "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-   "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-   "dev": true,
-   "requires": {
-    "babel-code-frame": "^6.26.0",
-    "babel-messages": "^6.23.0",
-    "babel-runtime": "^6.26.0",
-    "babel-types": "^6.26.0",
-    "babylon": "^6.18.0",
-    "debug": "^2.6.8",
-    "globals": "^9.18.0",
-    "invariant": "^2.2.2",
-    "lodash": "^4.17.4"
-   }
-  },
-  "babel-types": {
-   "version": "6.26.0",
-   "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-   "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-   "dev": true,
-   "requires": {
-    "babel-runtime": "^6.26.0",
-    "esutils": "^2.0.2",
-    "lodash": "^4.17.4",
-    "to-fast-properties": "^1.0.3"
-   }
-  },
-  "babylon": {
-   "version": "6.18.0",
-   "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-   "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-   "dev": true
   },
   "balanced-match": {
    "version": "1.0.0",
@@ -1888,19 +2681,6 @@
    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
    "dev": true
   },
-  "chalk": {
-   "version": "1.1.3",
-   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-   "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-   "dev": true,
-   "requires": {
-    "ansi-styles": "^2.2.1",
-    "escape-string-regexp": "^1.0.2",
-    "has-ansi": "^2.0.0",
-    "strip-ansi": "^3.0.0",
-    "supports-color": "^2.0.0"
-   }
-  },
   "char-regex": {
    "version": "1.0.2",
    "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -2041,12 +2821,6 @@
    "version": "0.1.1",
    "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
    "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-   "dev": true
-  },
-  "core-js": {
-   "version": "2.6.5",
-   "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-   "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
    "dev": true
   },
   "core-util-is": {
@@ -2207,15 +2981,6 @@
    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
    "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
    "dev": true
-  },
-  "detect-indent": {
-   "version": "4.0.0",
-   "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-   "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-   "dev": true,
-   "requires": {
-    "repeating": "^2.0.0"
-   }
   },
   "detect-newline": {
    "version": "3.1.0",
@@ -2702,12 +3467,6 @@
     "path-is-absolute": "^1.0.0"
    }
   },
-  "globals": {
-   "version": "9.18.0",
-   "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-   "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-   "dev": true
-  },
   "graceful-fs": {
    "version": "4.2.4",
    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -2740,15 +3499,6 @@
    "requires": {
     "ajv": "^6.5.5",
     "har-schema": "^2.0.0"
-   }
-  },
-  "has-ansi": {
-   "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-   "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-   "dev": true,
-   "requires": {
-    "ansi-regex": "^2.0.0"
    }
   },
   "has-flag": {
@@ -2807,16 +3557,6 @@
       "is-buffer": "^1.1.5"
      }
     }
-   }
-  },
-  "home-or-tmp": {
-   "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-   "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-   "dev": true,
-   "requires": {
-    "os-homedir": "^1.0.0",
-    "os-tmpdir": "^1.0.1"
    }
   },
   "hosted-git-info": {
@@ -2897,15 +3637,6 @@
    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
    "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
    "dev": true
-  },
-  "invariant": {
-   "version": "2.2.4",
-   "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-   "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-   "dev": true,
-   "requires": {
-    "loose-envify": "^1.0.0"
-   }
   },
   "ip-regex": {
    "version": "2.1.0",
@@ -3005,15 +3736,6 @@
    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
    "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
    "dev": true
-  },
-  "is-finite": {
-   "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-   "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-   "dev": true,
-   "requires": {
-    "number-is-nan": "^1.0.0"
-   }
   },
   "is-fullwidth-code-point": {
    "version": "3.0.0",
@@ -4828,12 +5550,6 @@
     }
    }
   },
-  "js-tokens": {
-   "version": "3.0.2",
-   "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-   "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-   "dev": true
-  },
   "js-yaml": {
    "version": "3.14.0",
    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
@@ -4884,12 +5600,6 @@
     "xml-name-validator": "^3.0.0"
    }
   },
-  "jsesc": {
-   "version": "1.3.0",
-   "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-   "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-   "dev": true
-  },
   "json-parse-better-errors": {
    "version": "1.0.2",
    "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -4912,12 +5622,6 @@
    "version": "5.0.1",
    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
    "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-   "dev": true
-  },
-  "json5": {
-   "version": "0.5.1",
-   "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-   "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
    "dev": true
   },
   "jsprim": {
@@ -4992,15 +5696,6 @@
    "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
    "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
    "dev": true
-  },
-  "loose-envify": {
-   "version": "1.4.0",
-   "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-   "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-   "dev": true,
-   "requires": {
-    "js-tokens": "^3.0.0 || ^4.0.0"
-   }
   },
   "make-dir": {
    "version": "3.1.0",
@@ -5126,15 +5821,6 @@
       "is-plain-object": "^2.0.4"
      }
     }
-   }
-  },
-  "mkdirp": {
-   "version": "0.5.5",
-   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-   "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-   "dev": true,
-   "requires": {
-    "minimist": "^1.2.5"
    }
   },
   "mock-require": {
@@ -5274,12 +5960,6 @@
     "path-key": "^2.0.0"
    }
   },
-  "number-is-nan": {
-   "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-   "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-   "dev": true
-  },
   "nwsapi": {
    "version": "2.2.0",
    "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -5372,18 +6052,6 @@
     "type-check": "~0.3.2",
     "word-wrap": "~1.2.3"
    }
-  },
-  "os-homedir": {
-   "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-   "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-   "dev": true
-  },
-  "os-tmpdir": {
-   "version": "1.0.2",
-   "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-   "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-   "dev": true
   },
   "p-each-series": {
    "version": "2.1.0",
@@ -5541,12 +6209,6 @@
     }
    }
   },
-  "private": {
-   "version": "0.1.8",
-   "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-   "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-   "dev": true
-  },
   "prompts": {
    "version": "2.3.2",
    "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
@@ -5635,12 +6297,6 @@
     "type-fest": "^0.8.1"
    }
   },
-  "regenerator-runtime": {
-   "version": "0.11.1",
-   "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-   "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-   "dev": true
-  },
   "regex-not": {
    "version": "1.0.2",
    "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -5668,15 +6324,6 @@
    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
    "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
    "dev": true
-  },
-  "repeating": {
-   "version": "2.0.1",
-   "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-   "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-   "dev": true,
-   "requires": {
-    "is-finite": "^1.0.0"
-   }
   },
   "request": {
    "version": "2.88.2",
@@ -6066,12 +6713,6 @@
    "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
    "dev": true
   },
-  "slash": {
-   "version": "1.0.0",
-   "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-   "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
-   "dev": true
-  },
   "snapdragon": {
    "version": "0.8.2",
    "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -6196,15 +6837,6 @@
     "resolve-url": "^0.2.1",
     "source-map-url": "^0.4.0",
     "urix": "^0.1.0"
-   }
-  },
-  "source-map-support": {
-   "version": "0.4.18",
-   "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-   "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-   "dev": true,
-   "requires": {
-    "source-map": "^0.5.6"
    }
   },
   "source-map-url": {
@@ -6376,15 +7008,6 @@
     }
    }
   },
-  "strip-ansi": {
-   "version": "3.0.1",
-   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-   "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-   "dev": true,
-   "requires": {
-    "ansi-regex": "^2.0.0"
-   }
-  },
   "strip-bom": {
    "version": "4.0.0",
    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -6401,12 +7024,6 @@
    "version": "2.0.0",
    "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
    "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-   "dev": true
-  },
-  "supports-color": {
-   "version": "2.0.0",
-   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-   "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
    "dev": true
   },
   "supports-hyperlinks": {
@@ -6469,12 +7086,6 @@
    "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
    "dev": true
   },
-  "to-fast-properties": {
-   "version": "1.0.3",
-   "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-   "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-   "dev": true
-  },
   "to-object-path": {
    "version": "0.3.0",
    "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -6535,12 +7146,6 @@
    "requires": {
     "punycode": "^2.1.1"
    }
-  },
-  "trim-right": {
-   "version": "1.0.1",
-   "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-   "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-   "dev": true
   },
   "ts-jest": {
    "version": "26.1.0",

--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
   "isoly": "0.0.14"
  },
  "devDependencies": {
+  "@babel/core": "^7.11.0",
   "@types/jest": "^26.0.0",
   "@types/node": "^14.0.13",
-  "babel-core": "^6.26.3",
   "babel-jest": "^26.0.1",
   "jest": "^26",
   "ts-jest": "^26.1.0",


### PR DESCRIPTION
## Change
Added @babel/core package and removed babel-core.

## Rationale
@babel/core is the new version of Babel-core. Old Babel-core use an old version of Lodash with security issues.

## Impact
No impact on functionality.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.