### PR TITLE
Card verification

### DIFF
--- a/Card/Creatable.spec.ts
+++ b/Card/Creatable.spec.ts
@@ -17,4 +17,47 @@ describe("Card.Creatable", () => {
 		}
 		expect(model.Card.Creatable.is(card)).toBeTruthy()
 	})
+	it("is card with verification (pares)", async () => {
+		const card: model.Card.Creatable = {
+			pan: "5105105105105100",
+			expires: [2, 22],
+			csc: "123",
+			verification: {
+				type: "pares",
+				data: "examplepares"
+			}
+		}
+		expect(model.Card.Creatable.is(card)).toBeTruthy()
+	})
+	it("is card with verification (method)", async () => {
+		const card: model.Card.Creatable = {
+			pan: "4111111111111111",
+			expires: [2, 22],
+			csc: "123",
+			verification: {
+				type: "method",
+				data: {
+					someProperty: "example1",
+					anotherProperty: "example2"
+				}
+			}
+		}
+		expect(model.Card.Creatable.is(card)).toBeTruthy()
+	})
+	it("is card with verification (challenge)", async () => {
+		const card: model.Card.Creatable = {
+			pan: "4111111111111111",
+			expires: [2, 22],
+			csc: "123",
+			verification: {
+				type: "challenge",
+				data: {
+					something: "example3",
+					another: "example4",
+					nothing: "",
+				}
+			}
+		}
+		expect(model.Card.Creatable.is(card)).toBeTruthy()
+	})
 })

--- a/Card/Creatable.ts
+++ b/Card/Creatable.ts
@@ -6,6 +6,7 @@ export interface Creatable {
 	expires: Expires
 	csc?: string
 	pares?: string
+	verification?: { type: "pares" | "method" | "challenge", data?: string | { [property: string]: string }}
 }
 
 export namespace Creatable {
@@ -14,6 +15,19 @@ export namespace Creatable {
 			typeof(value.pan) == "string" &&
 			Expires.is(value.expires) &&
 			(value.csc == undefined || typeof(value.csc) == "string") &&
-			(value.pares == undefined || typeof(value.pares) == "string")
+			(value.pares == undefined || typeof(value.pares) == "string") &&
+			(value.verification == undefined || typeof(value.verification) == "object" &&
+				(
+					value.verification.type == "pares" ||
+					value.verification.type == "method" ||
+					value.verification.type == "challenge"
+				)
+				&&
+				(
+					value.verification.data == undefined ||
+					typeof value.verification.data == "string" ||
+					typeof value.verification.data == "object" && Object.values(value.verification.data).every(item => typeof item == "string")
+				)
+			)
 	}
 }

--- a/Card/Token.spec.ts
+++ b/Card/Token.spec.ts
@@ -74,4 +74,72 @@ describe("Card Token", () => {
 		const withInfoPayloaded = verifiedWithInfo && { ...originalTokenWithInfo, aud: verifiedWithInfo.aud, iss: verifiedWithInfo.iss, iat: verifiedWithInfo.iat }
 		expect(verifiedWithInfo).toEqual(withInfoPayloaded)
 	})
+	it("valid with pares verification (no verification data allowed)", async () => {
+		const card: model.Card.Token = {
+			type: "single use",
+			card: "12345678",
+			scheme: "visa",
+			iin: "411111",
+			last4: "1111",
+			expires: [12, 26],
+			verification: {
+				type: "pares",
+			}
+		}
+		expect(model.Card.Token.hasInfo(card)).toBeTruthy()
+		expect(model.Card.Token.is(card)).toBeTruthy()
+	})
+	it("non-valid with pares verification (because of no verification data allowed)", async () => {
+		const card: model.Card.Token = {
+			type: "single use",
+			card: "12345678",
+			scheme: "visa",
+			iin: "411111",
+			last4: "1111",
+			expires: [12, 26],
+			verification: {
+				type: "pares",
+				data: "not allowed for card token with verification type pares"
+			}
+		}
+		expect(model.Card.Token.is(card)).toBeFalsy()
+	})
+	it("valid with method verification (method verification don't store any sensitive data)", async () => {
+		const card: model.Card.Token = {
+			type: "single use",
+			card: "12345678",
+			scheme: "visa",
+			iin: "411111",
+			last4: "1111",
+			expires: [12, 26],
+			verification: {
+				type: "method",
+				data: {
+					someProperty: "example1",
+					anotherProperty: "example2"
+				}
+			}
+		}
+		expect(model.Card.Token.hasInfo(card)).toBeTruthy()
+		expect(model.Card.Token.is(card)).toBeTruthy()
+	})
+	it("valid with method verification (method verification don't store any sensitive data)", async () => {
+		const card: model.Card.Token = {
+			type: "single use",
+			card: "12345678",
+			scheme: "visa",
+			iin: "411111",
+			last4: "1111",
+			expires: [12, 26],
+			verification: {
+				type: "challenge",
+				data: {
+					oneProperty: "example3",
+					aProperty: "example4"
+				}
+			}
+		}
+		expect(model.Card.Token.hasInfo(card)).toBeTruthy()
+		expect(model.Card.Token.is(card)).toBeTruthy()
+	})
 })

--- a/Card/Token.spec.ts
+++ b/Card/Token.spec.ts
@@ -41,6 +41,17 @@ describe("Card Token", () => {
 		expect(model.Card.Token.hasInfo(card)).toBeTruthy()
 		expect(model.Card.Token.is(card)).toBeTruthy()
 	})
+	it("is card token with verification (pares) indicator, no pares allowed in token", async () => {
+		const card: model.Card.Creatable = {
+			pan: "5105105105105100",
+			expires: [2, 22],
+			csc: "123",
+			verification: {
+				type: "pares"
+			}
+		}
+		expect(model.Card.Creatable.is(card)).toBeTruthy()
+	})
 	it("Verifying tokens signed in backend", async () => {
 		const originalMinimalToken: model.Card.Token = {
 			type: "single use",

--- a/Card/Token.ts
+++ b/Card/Token.ts
@@ -10,6 +10,7 @@ export interface Token {
 	iin?: string
 	last4?: string
 	expires?: Expires
+	verification?: { type: "pares" | "method" | "challenge", data?: string | { [property: string]: string }}
 }
 
 export namespace Token {
@@ -20,7 +21,20 @@ export namespace Token {
 			(value.scheme == undefined || Scheme.is(value.scheme)) &&
 			(value.iin == undefined || typeof value.iin == "string" && value.iin.length == 6) &&
 			(value.last4 == undefined || typeof value.last4 == "string" && value.last4.length == 4) &&
-			(value.expires == undefined || Expires.is(value.expires))
+			(value.expires == undefined || Expires.is(value.expires)) &&
+			(value.verification == undefined || typeof(value.verification) == "object" &&
+				(
+					value.verification.type == "pares" ||
+					value.verification.type == "method" ||
+					value.verification.type == "challenge"
+				)
+				&&
+				(
+					value.verification.data == undefined ||
+					typeof value.verification.data == "string" ||
+					typeof value.verification.data == "object" && Object.values(value.verification.data).every(item => typeof item == "string")
+				)
+			)
 	}
 	export function hasInfo(value: Token | any): value is Token & { scheme: Scheme, iin: string, last4: string, expires: Expires } {
 		return is(value) &&

--- a/Card/Token.ts
+++ b/Card/Token.ts
@@ -24,7 +24,7 @@ export namespace Token {
 			(value.expires == undefined || Expires.is(value.expires)) &&
 			(value.verification == undefined || typeof(value.verification) == "object" &&
 				(
-					value.verification.type == "pares" ||
+					value.verification.type == "pares" && value.verification.data == undefined ||
 					value.verification.type == "method" ||
 					value.verification.type == "challenge"
 				)


### PR DESCRIPTION
## Change
Add verification type indicator and data to card creatable and to card token (except for token: no data allowed when type == "pares").

## Rationale
To add information about where in verification flow a card payment or account creation is. Only highly specified transaction id:s and similar data will be permissable as verification data. This update is also done to standardize verification data used with cards.

## Impact
When verification type is "pares" then no verification data will be allowed in the card token. "is" method will fail if that is the case. It will because of that fail early in development to make it impossible to make a mistake ("is" check is always performed during verification of card tokens, which will fail verification already when testing).

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
