### PR TITLE
verification property added to Card.Change

### DIFF
--- a/Card/Change.spec.ts
+++ b/Card/Change.spec.ts
@@ -1,0 +1,61 @@
+import * as model from "../index"
+
+describe("Card.Change", () => {
+	it("pan & expires", async () => {
+		const card: model.Card.Change = {
+			pan: "4111111111111111",
+			expires: [12, 20],
+		}
+		expect(model.Card.Change.is(card)).toBeTruthy()
+	})
+	it("is (empty) Partial<Creatable>", async () => {
+		const card: model.Card.Change = {}
+		expect(model.Card.Change.is(card)).toBeTruthy()
+	})
+	it("is card with verification (pares)", async () => {
+		const card: model.Card.Change = {
+			pan: "4111111111111111",
+			expires: [2, 22],
+			csc: "123",
+			verification: {
+				type: "pares",
+				data: "examplepares"
+			}
+		}
+		expect(model.Card.Change.is(card)).toBeTruthy()
+	})
+	it("is card with pan & verification (method)", async () => {
+		const card: model.Card.Change = {
+			pan: "4111111111111111",
+			verification: {
+				type: "method",
+				data: {
+					someProperty: "example1",
+					anotherProperty: "example2"
+				}
+			}
+		}
+		expect(model.Card.Change.is(card)).toBeTruthy()
+	})
+	it("is card with csc and verification (challenge)", async () => {
+		const card: model.Card.Change = {
+			csc: "123",
+			verification: {
+				type: "challenge",
+				data: {
+					something: "example3",
+					another: "example4",
+					nothing: "",
+				}
+			}
+		}
+		expect(model.Card.Change.is(card)).toBeTruthy()
+	})
+	it("is (not) card with csc and verification as string", async () => {
+		const card = {
+			csc: "123",
+			verification: "not valid",
+		}
+		expect(model.Card.Change.is(card)).toBeFalsy()
+	})
+})

--- a/Card/Change.ts
+++ b/Card/Change.ts
@@ -10,7 +10,20 @@ export namespace Change {
 			(value.pan == undefined || typeof(value.pan) == "string") &&
 			(value.expires == undefined || Expires.is(value.expires)) &&
 			(value.csc == undefined || typeof(value.csc) == "string") &&
-			(value.pares == undefined || typeof(value.pares) == "string")
+			(value.pares == undefined || typeof(value.pares) == "string") &&
+			(value.verification == undefined || typeof(value.verification) == "object" &&
+				(
+					value.verification.type == "pares" ||
+					value.verification.type == "method" ||
+					value.verification.type == "challenge"
+				)
+				&&
+				(
+					value.verification.data == undefined ||
+					typeof value.verification.data == "string" ||
+					typeof value.verification.data == "object" && Object.values(value.verification.data).every(item => typeof item == "string")
+				)
+			)
 	}
 	export function flaw(value: Change | any): gracely.Flaw {
 		return {
@@ -21,6 +34,19 @@ export namespace Change {
 					value.expires == undefined || Expires.is(value.expires) || { property: "expires", type: "string | undefined" },
 					value.csc == undefined || typeof(value.csc) == "string" || { property: "csc", type: "string | undefined" },
 					value.pares == undefined || typeof(value.pares) == "string" || { property: "pares", type: "string | undefined" },
+					(value.verification == undefined || typeof(value.verification) == "object" &&
+						(
+							value.verification.type == "pares" ||
+							value.verification.type == "method" ||
+							value.verification.type == "challenge"
+						)
+						&&
+						(
+							value.verification.data == undefined ||
+							typeof value.verification.data == "string" ||
+							typeof value.verification.data == "object" && Object.values(value.verification.data).every(item => typeof item == "string")
+						)
+					) || { property: "verification", type: '{ type: "pares" | "method" | "challenge", data?: string | { [property: string]: string }} | undefined' },
 				].filter(gracely.Flaw.is) as gracely.Flaw[],
 		}
 	}


### PR DESCRIPTION
## Change
Added verification property from Card.Creatable to Card.Change (which is a Partial<Card.Creatable>).

## Rationale
Card.Change should mirror Card.Creatable, except that all properties should be optional.

## Impact
Allows addition and removal of verification data of an existing card without having to provide all previous data.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
