### PR TITLE
Card verification must be able to store more types

### DIFF
--- a/Card/Creatable.ts
+++ b/Card/Creatable.ts
@@ -7,7 +7,7 @@ export interface Creatable {
 	expires: Expires
 	csc?: string
 	pares?: string
-	verification?: { type: "pares" | "method" | "challenge", data?: string | { [property: string]: string }}
+	verification?: { type: "pares" | "method" | "challenge", data?: string | { [property: string]: any }}
 	client?: { ip?: string, browser?: Browser | Browser.Creatable }
 }
 
@@ -28,7 +28,7 @@ export namespace Creatable {
 				(
 					value.verification.data == undefined ||
 					typeof value.verification.data == "string" ||
-					typeof value.verification.data == "object" && Object.values(value.verification.data).every(item => typeof item == "string")
+					typeof value.verification.data == "object"
 				)
 			) &&
 			(value.client == undefined || typeof value.client == "object" &&

--- a/Card/Token.ts
+++ b/Card/Token.ts
@@ -10,7 +10,7 @@ export interface Token {
 	iin?: string
 	last4?: string
 	expires?: Expires
-	verification?: { type: "pares" | "method" | "challenge", data?: string | { [property: string]: string }}
+	verification?: { type: "pares" | "method" | "challenge", data?: string | { [property: string]: any }}
 }
 
 export namespace Token {
@@ -32,7 +32,7 @@ export namespace Token {
 				(
 					value.verification.data == undefined ||
 					typeof value.verification.data == "string" ||
-					typeof value.verification.data == "object" && Object.values(value.verification.data).every(item => typeof item == "string")
+					typeof value.verification.data == "object"
 				)
 			)
 	}


### PR DESCRIPTION
## Change
Card verification will be able to store json-objects including properties other than of type strings.

## Rationale
Card verification needs to be able to store json-objects from responses to 3-D Secure Version 2 endpoints /auth or /postauth.

## Impact
Less strict .is() checks, already stores part of responses of 3-D Secure version 2 endpoint information.

## Risk
This should have no increased risks on the system. No extra risk analysis is necessary.

## Rollback
For rollback, it is enough to revert the commit and redeploy.
